### PR TITLE
splitting on two blanks or tab causes problem

### DIFF
--- a/src/main/python/isphere/command/core_command.py
+++ b/src/main/python/isphere/command/core_command.py
@@ -137,7 +137,7 @@ class CoreCommand(Cmd):
             if not _input(message).lower() == "y":
                 return []
 
-        actual_patterns = patterns.strip().split(" ")
+        actual_patterns = patterns.strip().split()
         try:
             compiled_patterns = [re.compile(pattern) for pattern in actual_patterns]
         except Exception as e:


### PR DESCRIPTION
If two blanks are used in the pattern the matching behaves unexpectedly.

using the default behavior is more usefull
(the words are separated by arbitrary strings of whitespace characters (space, tab, newline, return, formfeed))
