### PR TITLE
This removes task state polling from do_shutdown_vm

### DIFF
--- a/src/main/python/isphere/command/virtual_machine_command.py
+++ b/src/main/python/isphere/command/virtual_machine_command.py
@@ -118,7 +118,7 @@ class VirtualMachineCommand(CoreCommand):
             print("Asking {0} to reboot".format(vm_name))
             self.retrieve_vm(vm_name).RebootGuest()
 
-    def do_shutdown_vm(self, patterns, ask=True, wait=True):
+    def do_shutdown_vm(self, patterns, ask=True):
         """Usage: shutdown_vm [pattern1 [pattern2]...]
         shutdown vms matching the given ORed name patterns.
 
@@ -128,13 +128,11 @@ class VirtualMachineCommand(CoreCommand):
         for vm_name in self.compile_and_yield_vm_patterns(patterns, True, ask):
             print("Asking {0} to stop".format(vm_name))
             try:
-                task = self.retrieve_vm(vm_name).ShutdownGuest()
+                #Todo: allow vm state polling to make this a synchronous call if needed
+                self.retrieve_vm(vm_name).ShutdownGuest()
             except vim.fault.InvalidPowerState:
                 print("Success")
                 return
-            if wait:
-                self.wait_for_task_to_complete(task)
-                print("Success")
 
         return
 

--- a/src/main/python/isphere/command/virtual_machine_command.py
+++ b/src/main/python/isphere/command/virtual_machine_command.py
@@ -128,7 +128,7 @@ class VirtualMachineCommand(CoreCommand):
         for vm_name in self.compile_and_yield_vm_patterns(patterns, True, ask):
             print("Asking {0} to stop".format(vm_name))
             try:
-                #Todo: allow vm state polling to make this a synchronous call if needed
+                # Todo: allow vm state polling to make this a synchronous call if needed
                 self.retrieve_vm(vm_name).ShutdownGuest()
             except vim.fault.InvalidPowerState:
                 print("Success")

--- a/src/unittest/python/command_tests.py
+++ b/src/unittest/python/command_tests.py
@@ -324,7 +324,7 @@ class VSphereREPLTests(TestCase):
 
         cache_retrieve.side_effect = [mock_vm1, mock_vm2]
 
-        self.assertEquals(None, self.repl.do_shutdown_vm("any.*", wait=True))
+        self.assertEquals(None, self.repl.do_shutdown_vm("any.*"))
         mock_vm1.ShutdownGuest.assert_called_with()
         mock_vm2.ShutdownGuest.assert_called_with()
 
@@ -341,7 +341,7 @@ class VSphereREPLTests(TestCase):
 
         cache_retrieve.side_effect = [mock_vm1, mock_vm2]
 
-        self.assertRaises(Exception, lambda: self.assertFalse(self.repl.do_shutdown_vm("any.*", wait=True)))
+        self.assertFalse(self.repl.do_shutdown_vm("any.*"))
         mock_vm1.ShutdownGuest.assert_called_with()
 
     @patch("isphere.command.core_command.CachingVSphere.retrieve_vm")

--- a/src/unittest/python/command_tests.py
+++ b/src/unittest/python/command_tests.py
@@ -312,15 +312,10 @@ class VSphereREPLTests(TestCase):
         mock_vm2.RebootGuest.assert_called_with()
 
     @patch("isphere.command.core_command.CachingVSphere.retrieve_vm")
-    def test_do_shutdown_vm_returns_true_on_success(self, cache_retrieve):
+    def test_do_shutdown_vm_calls_shutdown_guest_for_given_vms(self, cache_retrieve):
         self.vm_names.return_value = ["any-host-1", "any-host-2"]
         mock_vm1 = Mock()
         mock_vm2 = Mock()
-
-        success_task_mock = Mock()
-        success_task_mock.info.state = 'success'
-        mock_vm1.ShutdownGuest.return_value = success_task_mock
-        mock_vm2.ShutdownGuest.return_value = success_task_mock
 
         cache_retrieve.side_effect = [mock_vm1, mock_vm2]
 
@@ -329,23 +324,7 @@ class VSphereREPLTests(TestCase):
         mock_vm2.ShutdownGuest.assert_called_with()
 
     @patch("isphere.command.core_command.CachingVSphere.retrieve_vm")
-    def test_do_shutdown_vm_raises_exception_on_any_error(self, cache_retrieve):
-        self.vm_names.return_value = ["any-host-1", "any-host-2"]
-        mock_vm1 = Mock()
-        mock_vm2 = Mock()
-
-        success_task_mock = Mock()
-        success_task_mock.info.state = 'error'
-        mock_vm1.ShutdownGuest.return_value = success_task_mock
-        mock_vm2.ShutdownGuest.return_value = success_task_mock
-
-        cache_retrieve.side_effect = [mock_vm1, mock_vm2]
-
-        self.assertFalse(self.repl.do_shutdown_vm("any.*"))
-        mock_vm1.ShutdownGuest.assert_called_with()
-
-    @patch("isphere.command.core_command.CachingVSphere.retrieve_vm")
-    def test_do_startup_vm_returns_nothing_on_success(self, cache_retrieve):
+    def test_do_startup_vm_calls_power_on_for_given_vms(self, cache_retrieve):
         self.vm_names.return_value = ["any-host-1", "any-host-2"]
         mock_vm1 = Mock()
         mock_vm2 = Mock()


### PR DESCRIPTION
The pyVmomi ShutdownGuest() call on a VM entity doesn't return a Task. This makes state polling impossible. The call is fire&forget. Another solution would be to poll on the vm power state afterwards. Will try this later on.
